### PR TITLE
kde native support

### DIFF
--- a/git-dude
+++ b/git-dude
@@ -36,6 +36,8 @@ function notify() {
     notify-send -i "$1" "$2" "$3"
   elif [ $(which growlnotify 2>/dev/null) ]; then
     growlnotify --image "$1" -m "$3" "$2"
+  elif [ $(which kdialog 2>/dev/null) ]; then
+    kdialog --icon $1 --title "$2" --passivepopup "$3"
   else
     echo $2; echo $3
   fi


### PR DESCRIPTION
Hi, i've patched the script for people using KD3 / KDE4.
Kdialog is native to the K enviroment as opposed to lib-notify which is Gnome based.
