### PR TITLE
Fixed looking for dirs with spaces

### DIFF
--- a/git-dude
+++ b/git-dude
@@ -41,8 +41,8 @@ function notify() {
 
 while true; do
   for dir_name in *; do
-    if [[ -d $dir_name && $(cd $dir_name; git rev-parse --git-dir 2>/dev/null) ]]; then
-      repo_name=$(basename $dir_name .git)
+    if [[ -d "$dir_name" && $(cd "$dir_name"; git rev-parse --git-dir 2>/dev/null) ]]; then
+      repo_name=$(basename "$dir_name" .git)
       cd "$dir_name"
 
       changes=$(git fetch 2>&1 | grep -F -- '->' | sed -E 's/^\s+\+\s+//')


### PR DESCRIPTION
When git-dude looks for git repositories, it will break on directories with spaces in the name.

To reproduce, clone a repository into git-dude's working folder. Change the name of the directory to include a space, for example, "my repo". Upon running git-dude, bash will give an error saying `git-dude/git-dude: line 44: cd: my: No such file or directory`.

This commit fixes the problem by wrapping the directory names in double quotes.
