### PR TITLE
Brew  command update

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ on your `$PATH`.
 
 Git-dude can be installed with the following command:
 
-`brew install https://raw.github.com/gist/1289314/git-dude.rb`
+`brew install https://raw.github.com/gist/1289314/git-dude.rb --HEAD`
 
 The homebrew formula lives [here](https://gist.github.com/1289314).
 


### PR DESCRIPTION
Updates commad for installing via homebrew. It now requires `--HEAD` param:

```
% brew install https://raw.github.com/gist/1289314/git-dude.rb
Error: This is a head-only formula; install with `brew install --HEAD git-dude
```
