### PR TITLE
One pretty large fix to avoid a infinite loop

### DIFF
--- a/git-dude
+++ b/git-dude
@@ -37,10 +37,10 @@ elif [ $(which growlnotify 2>/dev/null) ]; then
 elif [ $(which kdialog 2>/dev/null) ]; then
   notify_cmd='kdialog --icon $ICON_PATH --title "$TITLE" --passivepopup "$DESCRIPTION"'
 elif [ $(which notify 2>/dev/null) ]; then
-  notify_cmd='notify --type information --icon $ICON_PATH --group "Git Commit" --title "$TITLE" "$DESCRIPTION"'
+  notify_cmd='notify --type information --icon "$ICON_PATH" --group "Git Commit" --title "$TITLE" "$DESCRIPTION"'
 fi
 
-function notify() {
+function dudenotify() {
   local ICON_PATH="$1"
   local TITLE="$2"
   local DESCRIPTION="$3"
@@ -82,15 +82,15 @@ while true; do
             commit_range=$(echo "$line" | awk '{ print $1 }')
             branch_name=$(echo "$line" | awk '{ print $2 }')
             commit_messages=$(git log $commit_range --pretty=format:'%s (%an)')
-            notify $icon_path "New commits in $repo_name/$branch_name" "$commit_messages"
+            dudenotify $icon_path "New commits in $repo_name/$branch_name" "$commit_messages"
             ;;
           *new\ branch*)
             branch_name=$(echo "$line" | awk '{ print $3 }')
-            notify $icon_path "New branch $repo_name/$branch_name" ""
+            dudenotify $icon_path "New branch $repo_name/$branch_name" ""
             ;;
           *new\ tag*)
             tag_name=$(echo "$line" | awk '{ print $3 }')
-            notify $icon_path "New tag $repo_name/$tag_name" ""
+            dudenotify $icon_path "New tag $repo_name/$tag_name" ""
             ;;
         esac
       done <<< "$changes"


### PR DESCRIPTION
- The nofify function in git-dude clashes with
  the notify application on Haiku causing an
  infinite loop.  Rename notify to dudenotify.
- Correct missing quotes from Haiku icon file.
