### PR TITLE
Escape spaces in $icon_path before eval

### DIFF
--- a/git-dude
+++ b/git-dude
@@ -74,6 +74,7 @@ while true; do
 
       icon_path=$(git config dude.icon || true)
       icon_path=${icon_path:-`pwd`/icon.png}
+      icon_path=${icon_path// /\\ } # escape spaces before eval
       eval icon_path=$icon_path # to expand ~
 
       while read -r line; do


### PR DESCRIPTION
The path to my Git repositories has a space in it (starts with ~/Josh/Git Repos/), which was causing this error to happen:

/Users/Josh/.bin/git-dude/git-dude: line 78: Repos/example/path/to/icon.png: No such file or directory

This change fixes that issue by escaping spaces before the eval of icon_path.
