### PR TITLE
Added terminal-notifier (for notification center) and github

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Ubuntu:
 OSX:
 
 ![git-dude on Mac OSX](https://github.com/downloads/sickill/git-dude/git-dude-osx-shot.png)
+
 ![git-dude on Mac OSX](http://f.cl.ly/items/0W2H200j441K392G160H/git-dude-notification-center.png)
 
 Haiku:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Ubuntu:
 OSX:
 
 ![git-dude on Mac OSX](https://github.com/downloads/sickill/git-dude/git-dude-osx-shot.png)
+![git-dude on Mac OSX](http://f.cl.ly/items/0W2H200j441K392G160H/git-dude-notification-center.png)
 
 Haiku:
 
@@ -39,6 +40,9 @@ On OSX:
 
 * `growlnotify`, from [Growl Extras](http://growl.info/extras.php#growlnotify)
   (Homebrew: _growlnotify_ package)
+
+* `terminal-notifier`, from [Alloy](https://github.com/alloy/terminal-notifier)
+  `[sudo] gem install terminal-notifier`
 
 ## Installation
 
@@ -90,6 +94,12 @@ to monitor instead of _pwd_.
 
 This way you can have multiple _dude directories_ each being monitored by
 separate git-dude process.
+
+## Github
+
+If the repo is on github and you are using `terminal-notifier` when you click
+on the notification banner you'll be redirected to the github project page that
+will show you the commit and if possible comparison with older one.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -134,3 +134,7 @@ Tell git-dude to ignore specific repository (if you want to _unmonitor_ it):
 ## Author
 
 Marcin Kulik (http://ku1ik.com/ | @sickill)
+
+## Contributors
+
+Davide D'Agostino (http://daddye.it | @DAddYE)

--- a/git-dude
+++ b/git-dude
@@ -38,26 +38,38 @@ elif [ $(which kdialog 2>/dev/null) ]; then
   notify_cmd='kdialog --icon $ICON_PATH --title "$TITLE" --passivepopup "$DESCRIPTION"'
 elif [ $(which notify 2>/dev/null) ]; then
   notify_cmd='notify --type information --icon "$ICON_PATH" --group "Git Commit" --title "$TITLE" "$DESCRIPTION"'
+elif [ $(which terminal-notifier 2>/dev/null) ]; then
+  notify_cmd='terminal-notifier -title "$TITLE" -message "$DESCRIPTION" -open "$URL"'
 fi
 
 function dudenotify() {
   local ICON_PATH="$1"
   local TITLE="$2"
   local DESCRIPTION="$3"
+  local URL="$4"
 
   if [ -n "$notify_cmd" ]; then
-    eval $notify_cmd
+    eval "$notify_cmd 2>/dev/null"
+    date "+%T %D"
+    echo "$TITLE"
+    if [ -n "$DESCRIPTION" ]; then
+      echo "$DESCRIPTION"
+    fi
+
+    if [ -n "$URL" ]; then
+      echo "$URL"
+    fi
+  else
+    echo "Sorry, you must install a notifier. Exiting ..."
+    exit 1
   fi
 
-  date "+%T %D"
-  echo "$TITLE"
-  if [ -n "$DESCRIPTION" ]; then
-    echo "$DESCRIPTION"
-  fi
   echo
 }
 
 [[ -d "$1" ]] && cd $1
+
+echo "Looking for changes in $(pwd) repos every $interval/s"
 
 while true; do
   for dir_name in *; do
@@ -70,12 +82,23 @@ while true; do
       repo_name=$(basename "$dir_name" .git)
       cd "$dir_name"
 
+
       changes=$(git fetch 2>&1 | grep -F -- '->' | sed 's/^ [+*=!-] //')
+
+      if [ -n "$changes" ]; then
+        echo "  new commits for $(pwd)"
+      else
+        echo "  nothing new for $(pwd)"
+      fi
 
       icon_path=$(git config dude.icon || true)
       icon_path=${icon_path:-`pwd`/icon.png}
       icon_path=${icon_path// /\\ } # escape spaces before eval
       eval icon_path=$icon_path # to expand ~
+
+      if [[ $(git config --local -l) =~ github.com[:/]([A-z0-9_-]+) ]]; then
+        url="https://github.com/${BASH_REMATCH[1]}/$repo_name"
+      fi
 
       while read -r line; do
         case $line in
@@ -83,15 +106,25 @@ while true; do
             commit_range=$(echo "$line" | awk '{ print $1 }')
             branch_name=$(echo "$line" | awk '{ print $2 }')
             commit_messages=$(git log $commit_range --pretty=format:'%s (%an)')
-            dudenotify $icon_path "New commits in $repo_name/$branch_name" "$commit_messages"
+            if [ -n "$url" ]; then
+              compare=$(echo "$line" | awk '{ print $1 }' | sed -E 's/[^\.]\.\.[^\.]/.../')
+              commit_url="$url/compare/$compare"
+            fi
+            dudenotify $icon_path "New commits in $repo_name/$branch_name" "$commit_messages" "$commit_url"
             ;;
           *new\ branch*)
             branch_name=$(echo "$line" | awk '{ print $3 }')
-            dudenotify $icon_path "New branch $repo_name/$branch_name" ""
+            if [ -n "$url" ]; then
+              commit_url="$url/commits/$branch_name"
+            fi
+            dudenotify $icon_path "New branch $repo_name/$branch_name" "Added the branch $branch_name" "$commit_url"
             ;;
           *new\ tag*)
             tag_name=$(echo "$line" | awk '{ print $3 }')
-            dudenotify $icon_path "New tag $repo_name/$tag_name" ""
+            if [ -n "$url" ]; then
+              commit_url="$url/commits/$tag_name"
+            fi
+            dudenotify $icon_path "New tag $repo_name/$tag_name" "Added the tag $tag_name" "$commit_url"
             ;;
         esac
       done <<< "$changes"

--- a/git-dude
+++ b/git-dude
@@ -107,7 +107,7 @@ while true; do
             branch_name=$(echo "$line" | awk '{ print $2 }')
             commit_messages=$(git log $commit_range --pretty=format:'%s (%an)')
             if [ -n "$url" ]; then
-              compare=$(echo "$line" | awk '{ print $1 }' | sed -E 's/[^\.]\.\.[^\.]/.../')
+              compare=$(echo "$line" | awk '{ print $1 }' | sed -E 's/\.\./.../')
               commit_url="$url/compare/$compare"
             fi
             dudenotify $icon_path "New commits in $repo_name/$branch_name" "$commit_messages" "$commit_url"


### PR DESCRIPTION
Hi!

thanks for this awesome script.

Since on Mountain Lion we have the notification center with [terminal-notifier](https://github.com/alloy/terminal-notifier) is quite easy to use it.

I also added (only for terminal-notifier) an open action, so if the repo is hosted on github when you click on the notification banner you will be redirected on the github project page, showing you the diff, the new branch or tag.

I'm not a *bash* expert so, if you accept this pull request, you should review my changes.

Thanks for your time!