### PR TITLE
Added support for terminal-notifier

### DIFF
--- a/git-dude
+++ b/git-dude
@@ -33,7 +33,7 @@ if [[ $(git config dude.notify-command) ]]; then
 elif [ $(which notify-send 2>/dev/null) ]; then
   notify_cmd='notify-send -i "$ICON_PATH" "$TITLE" "$DESCRIPTION"'
 elif [ $(which terminal-notifier 2>/dev/null) ]; then
-  notify_cmd='terminal-notifier --message "$DESCRIPTION" -title "$TITLE"'
+  notify_cmd='terminal-notifier -message "$DESCRIPTION" -title "$TITLE" -group "$app_name"'
 elif [ $(which growlnotify 2>/dev/null) ]; then
   notify_cmd='growlnotify -n "$app_name" --image "$ICON_PATH" -m "$DESCRIPTION" "$TITLE"'
 elif [ $(which kdialog 2>/dev/null) ]; then


### PR DESCRIPTION
terminal-notifier is an app that uses OS-X's Notification Center.

this will allow making use of the systems built-in notification center instead of growlnotify on OS-X

more info on terminal-notifier here:
https://github.com/alloy/terminal-notifier

Thank.
