### PR TITLE
Locale aware date and time representation

### DIFF
--- a/git-dude
+++ b/git-dude
@@ -49,7 +49,7 @@ function dudenotify() {
     eval $notify_cmd
   fi
 
-  date "+%T %D"
+  date "+%x %X"
   echo "$TITLE"
   if [ -n "$DESCRIPTION" ]; then
     echo "$DESCRIPTION"


### PR DESCRIPTION
This patch allows me to set `LC_TIME` and enjoy readable (to me) date and time representation.

``` bash
export LC_TIME="sv_SE.UTF-8"
```
