### PR TITLE
Pass description to terminal-notifier correctly

### DIFF
--- a/git-dude
+++ b/git-dude
@@ -20,7 +20,7 @@ if [[ $(git config dude.notify-command) ]]; then
 elif [ $(which notify-send 2>/dev/null) ]; then
   notify_cmd='notify-send -i "$ICON_PATH" "$TITLE" "$DESCRIPTION"'
 elif [ $(which terminal-notifier 2>/dev/null) ]; then
-  notify_cmd='terminal-notifier -title "$TITLE" -message"$DESCRIPTION"'
+  notify_cmd='terminal-notifier -title "$TITLE" -message "$DESCRIPTION"'
 elif [ $(which growlnotify 2>/dev/null) ]; then
   notify_cmd='growlnotify -n "$app_name" --image "$ICON_PATH" -m "$DESCRIPTION" "$TITLE"'
 elif [ $(which kdialog 2>/dev/null) ]; then


### PR DESCRIPTION
The `-message` argument and the associated description need to be passed as separate arguments, not as one string, or else it becomes a single flag `-message$THE_WHOLE_DESCRIPTION` which is not recognised by `terminal-notifier`.